### PR TITLE
fixed zero gap between .text and .rodata

### DIFF
--- a/nacl/dyn-link/ldscripts/elf64_nacl.x.static
+++ b/nacl/dyn-link/ldscripts/elf64_nacl.x.static
@@ -44,6 +44,7 @@ SECTIONS
   PROVIDE (etext = .);
 
   . = DEFINED(__nacl_rodata_start) ? __nacl_rodata_start : .;
+  . = . + 0x1f;
   . = ALIGN(CONSTANT (MAXPAGESIZE)); /* nacl wants page alignment */
   .note.gnu.build-id : { *(.note.gnu.build-id) } :seg_rodata
   .hash           : { *(.hash) }


### PR DESCRIPTION
when .text code was on the 32 byte boundary
there was no gap between .text and .rodata sections
which was making nacl loader very unhappy
fixed that by offseting location pointer with 0x1f padding (31 bytes)
the gap between .text and .rodata should be >= 32 bytes

fixes #6
