### PR TITLE
fix build under make 4.0x

### DIFF
--- a/configure
+++ b/configure
@@ -4587,7 +4587,7 @@ $as_echo_n "checking version of $MAKE... " >&6; }
   ac_prog_version=`$MAKE --version 2>&1 | sed -n 's/^.*GNU Make[^0-9]*\([0-9][0-9.]*\).*$/\1/p'`
   case $ac_prog_version in
     '') ac_prog_version="v. ?.??, bad"; ac_verc_fail=yes;;
-    3.79* | 3.[89]*)
+    3.79* | 3.[89]* | 4.0*)
        ac_prog_version="$ac_prog_version, ok"; ac_verc_fail=no;;
     *) ac_prog_version="$ac_prog_version, bad"; ac_verc_fail=yes;;
 


### PR DESCRIPTION
glibc configure is white-listing make versions 3.7.9, 3.8, 3.9 only
added whitelist for make 4.0